### PR TITLE
a1 - add a wait so browser has time to open

### DIFF
--- a/src/Browser.ts
+++ b/src/Browser.ts
@@ -81,7 +81,7 @@ export class Browser {
                     });
                 }
     
-                return page.goto(url)
+                return page.goto(url, {waitUntil: 'networkidle2'})
                 .then((response) => {
                     return <puppeteer.Response> response;
                 });

--- a/src/Browser.ts
+++ b/src/Browser.ts
@@ -81,7 +81,7 @@ export class Browser {
                     });
                 }
     
-                return page.goto(url, {waitUntil: 'networkidle2'})
+                return page.goto(url, { waitUntil: 'networkidle2' })
                 .then((response) => {
                     return <puppeteer.Response> response;
                 });


### PR DESCRIPTION
We needed to add a wait so that when the browser is set to open, it loads fully before we return the console 404 errors. 

@jasonbyrne we may have another change to be made but will only do so if needed. 