### PR TITLE
asyncfunction as an acceptable callback to .next

### DIFF
--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -1450,6 +1450,10 @@ export class Scenario implements iScenario {
       return b;
     } else if (aType == "function") {
       return a;
+    } else if (bType == "asyncfunction") {
+      return b;
+    } else if (aType == "asyncfunction") {
+      return a;
     } else if (bType == "object") {
       return this._expect(b);
     } else if (aType == "object") {


### PR DESCRIPTION
When Flagpole suites are compiled targeting ES2017 or later, `.toType()` on the callback function to `.next()` will return `asyncfunction` in `_getCallbackOverload`.

This throws an error:

```
Error: No callback provided.
    at Scenario._getCallbackOverload (/Users/johnsickels/Documents/code/playground/flagpole/node_modules/flagpole/dist/scenario.js:913:19)
```

Adding this returned value to the conditional fixes that. 😃 