### PR TITLE
allow "." in suite name

### DIFF
--- a/src/cli/cli-helper.ts
+++ b/src/cli/cli-helper.ts
@@ -140,7 +140,7 @@ export function promptTextName(
     initial: initial || "",
     format: trimInput,
     validate: (input: string) => {
-      return /^[a-z0-9][a-z0-9/\/_-]{1,62}[a-z0-9]$/i.test(input);
+      return /^[a-z0-9][a-z0-9\/_.-]{1,62}[a-z0-9]$/i.test(input);
     },
   };
 }


### PR DESCRIPTION
I want to allow names like
```
src/country/country.flagpole
```
but the CLI doesn't allow me to. The regex pattern fails and throws an error:
```
Please Enter A Valid Value
```

Also:
This pattern was not happy on regex101.com
```
^[a-z0-9][a-z0-9/\/_.-]{1,62}[a-z0-9]$
```
but this was
```
^[a-z0-9][a-z0-9\/_.-]{1,62}[a-z0-9]$
```

So I removed this first `/`. How do I test the local build in my CLI? Somehow point the global flagpole bin to the project `dist/`?