### PR TITLE
Use rimraf during tsc step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flagpole",
-  "version": "2.5.28",
+  "version": "2.5.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -75,6 +75,16 @@
         "@types/node": "*"
       }
     },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@types/jmespath/-/jmespath-0.15.0.tgz",
@@ -85,6 +95,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
       "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
+    },
+    "@types/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==",
+      "dev": true
     },
     "@types/mustache": {
       "version": "4.1.0",
@@ -150,6 +166,16 @@
       "dev": true,
       "requires": {
         "@types/puppeteer": "*"
+      }
+    },
+    "@types/rimraf": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
       }
     },
     "@types/tunnel": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@types/prompts": "^2.0.6",
     "@types/puppeteer": "^2.0.0",
     "@types/puppeteer-core": "^2.0.0",
+    "@types/rimraf": "^3.0.0",
     "@types/tunnel": "0.0.1",
     "@types/validator": "^13.1.3",
     "@types/yargs": "^15.0.4",

--- a/src/flagpoleconfig.ts
+++ b/src/flagpoleconfig.ts
@@ -2,6 +2,7 @@ import { normalizePath } from "./util";
 import { exec } from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
+import * as rimraf  from 'rimraf'
 
 export const getDefaultConfig = (configFilePath: string): iConfigOpts => {
   const projectPath = path.dirname(configFilePath);
@@ -471,14 +472,22 @@ export class FlagpoleConfig {
       const rootFolder = this.getRootFolder();
       const outFolder = this.getTestsFolder();
       const cwd = process.cwd();
-      const command = `cd ${rootFolder} && rm -Rf ${outFolder}/* && tsc && cd ${cwd}`;
-      exec(command, (err, stdout, stderr) => {
+      const rimRafPath = path.resolve(rootFolder, outFolder)
+      rimraf(rimRafPath, (err) => {
+
         if (err) {
-          reject(stdout || stderr || err);
-          return;
+          reject(err)
         }
-        resolve(stdout);
-      });
+
+        const command = `cd ${rootFolder} && tsc && cd ${cwd}`;
+        exec(command, (err, stdout, stderr) => {
+          if (err) {
+            reject(stdout || stderr || err);
+            return;
+          }
+          resolve(stdout);
+        });
+      })
     });
   }
 }


### PR DESCRIPTION
I noticed if you run on windows, not in a bash environment(like git bash, wsl), running with --build will fail because we use `rm`.

I switched this over to rimraf.