### PR TITLE
Chaining Assertions

### DIFF
--- a/flagpole.json
+++ b/flagpole.json
@@ -151,6 +151,11 @@
       "id": "",
       "name": "internal/ffprobe",
       "tags": []
+    },
+    "chaining-assertions": {
+      "id": "",
+      "name": "chaining-assertions",
+      "tags": []
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flagpole",
-  "version": "2.5.30",
+  "version": "2.5.31",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1771,7 +1771,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {

--- a/src/assertion.ts
+++ b/src/assertion.ts
@@ -890,7 +890,9 @@ export class Assertion implements iAssertion {
   public assert(message: string, value: any): iAssertion;
   public assert(value: any): iAssertion;
   public assert(a: any, b?: any): iAssertion {
-    return this._context.assert(a, b);
+    return arguments.length === 2
+      ? this._context.assert(a, b)
+      : this._context.assert(a);
   }
 
   /**

--- a/tests/src/chaining-assertions.ts
+++ b/tests/src/chaining-assertions.ts
@@ -1,0 +1,22 @@
+import flagpole from "../../dist/index";
+
+const suite = flagpole("Chaining Assertions");
+
+suite
+  .json("With undefined and assertion titles")
+  .open("https://www.milesplit.com/api/v1/meets")
+  .next(async (context) => {
+    context
+      .assert(context.response.statusCode)
+      .equals(200)
+      .assert("Status is OK", context.response.statusMessage)
+      .equals("OK")
+      .assert(context.response["fooBar"])
+      .equals(undefined)
+      .assert("undefined equals undefined", context.response["fooBar"])
+      .equals(undefined)
+      .assert(undefined)
+      .equals(undefined)
+      .assert("undefined equals undefined", undefined)
+      .equals(undefined);
+  });

--- a/tests/src/chaining-assertions.ts
+++ b/tests/src/chaining-assertions.ts
@@ -4,7 +4,7 @@ const suite = flagpole("Chaining Assertions");
 
 suite
   .json("With undefined and assertion titles")
-  .open("https://www.milesplit.com/api/v1/meets")
+  .open("https://reqres.in/api/users?page=1")
   .next(async (context) => {
     context
       .assert(context.response.statusCode)


### PR DESCRIPTION
Check number of arguments in the `iAssertion` `.assert(a, b?)` method in the same way the `iAssertionContext` handles arguments. 😄 

Test included ✅ 

Fixes #70 